### PR TITLE
Mark test as sequential to avoid concurrency issue

### DIFF
--- a/src/test/scala/com/box/castle/core/committer/CommitterActorTest.scala
+++ b/src/test/scala/com/box/castle/core/committer/CommitterActorTest.scala
@@ -39,6 +39,7 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 
 class CommitterActorTest extends Specification
 with Mockito with MockTools with NoTimeConversions {
+  sequential
 
   val lock = new Object()
   var numSynchronousCommitCallsWithErrorEnabled = 0


### PR DESCRIPTION
Mark test as sequential to avoid the potential concurrency issue