### PR TITLE
Mark CommitterActorTest as sequential to avoid concurrency issues

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.15

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.15

--- a/src/test/scala/com/box/castle/core/committer/CommitterActorTest.scala
+++ b/src/test/scala/com/box/castle/core/committer/CommitterActorTest.scala
@@ -39,6 +39,7 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 
 class CommitterActorTest extends Specification
 with Mockito with MockTools with NoTimeConversions {
+  sequential
 
   val lock = new Object()
   var numSynchronousCommitCallsWithErrorEnabled = 0


### PR DESCRIPTION
@denisgrenader 